### PR TITLE
chore(greenkeeper): Ignore aws-sdk updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,10 @@
   "optionalDependencies": {
     "coveralls": "^3.0.0",
     "jsdoc": "^3.5.5"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "aws-sdk"
+    ]
   }
 }


### PR DESCRIPTION
`aws-sdk` updates versions [too fast](https://www.npmjs.com/package/aws-sdk) (multiple times per week). Ignore it on greenkeeper.