### PR TITLE
Fix deployment and count articles

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: realworld
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs14.x
   region: us-east-1
   environment:
     DYNAMODB_NAMESPACE: ${opt:stage, "dev"}

--- a/src/Article.js
+++ b/src/Article.js
@@ -268,7 +268,8 @@ module.exports = {
     }
     return Util.envelop({
       articles: await queryEnoughArticles(queryParams, authenticatedUser,
-        limit, offset)
+        limit, offset),
+      articlesCount: await countArticles(queryParams, authenticatedUser)
     });
   },
 
@@ -317,6 +318,7 @@ module.exports = {
     return Util.envelop({
       articles: await queryEnoughArticles(queryParams, authenticatedUser,
         limit, offset),
+      articlesCount: await countArticles(queryParams, authenticatedUser)
     });
   },
 
@@ -377,6 +379,20 @@ async function queryEnoughArticles(queryParams, authenticatedUser,
     articlePromises.push(transformRetrievedArticle(a, authenticatedUser)));
   const articles = await Promise.all(articlePromises);
   return articles;
+}
+
+/**
+ * Given queryParams, return the number of articles that match.
+ */
+async function countArticles(queryParams, authenticatedUser,
+                                   limit, offset) {
+
+  const countQueryParams = Object.assign({}, queryParams, { Select: "COUNT" })
+  
+  const queryResult = await Util.DocumentClient.query(countQueryParams)
+      .promise();
+  
+  return queryResult.Count;
 }
 
 /**


### PR DESCRIPTION
Hello !

I'm preparing a demo on my realworld frontend project. I've decided to use your backend because it was easy to deploy for me (aws account already setup)

I've had to make some changes because : 
 - nodejs8 is not supported anymore on aws lambda
 - the "articlesCount" property was missing on the articles list endpoints.

I have no experience with DynamoDB or serverless, so feel free to close this MR if it's too far from what you'd have done.

These changes seem to work for me so I thought I'd contribute them if you want.